### PR TITLE
AdminMenu, Menu 추가

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,18 +1,31 @@
 import * as S from "../styles/Header.styles";
 import Logo from "../assets/img_logo.png";
 import { getMenuList } from "../hooks/getMenuList";
-import { useState } from "react";
-import { useNavigate } from "react-router";
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router";
 
 export default function Header() {
-  const [login] = useState({ user: "user" });
+  const [login, setLogin] = useState({ user: "user" });
+  const [onMenu, setonMenu] = useState<boolean>(false);
 
   const menuList = getMenuList(login);
   const navigate = useNavigate();
+  const locationObject = useLocation();
 
   const handleMoveToMenu = (path: string) => {
     navigate(path);
   };
+
+  const handleMenu = () => {
+    setonMenu(!onMenu);
+  };
+
+  // 로그인 구현 전에 임시로 만든 코드입니다.
+  useEffect(() => {
+    if (locationObject.pathname.includes("admin")) {
+      setLogin({ user: "admin" });
+    }
+  }, []);
 
   return (
     <S.HeaderContainer>
@@ -20,16 +33,47 @@ export default function Header() {
         <img src={Logo} alt="로고" />
       </S.LogoContainer>
       <S.MenuContainer>
-        {menuList.map((menu: any, index: number) => (
+        {login.user !== "admin" ? (
+          menuList.map((menu: any, index: number) => (
+            <S.Menu
+              key={index}
+              onClick={() => {
+                handleMoveToMenu(menu.path);
+              }}
+            >
+              {menu.label}
+            </S.Menu>
+          ))
+        ) : (
           <S.Menu
-            key={index}
             onClick={() => {
-              handleMoveToMenu(menu.path);
+              handleMenu();
             }}
           >
-            {menu.label}
+            MENU
           </S.Menu>
-        ))}
+        )}
+        {onMenu && (
+          <S.Overlay
+            onClick={() => {
+              handleMenu();
+            }}
+          >
+            <S.AdminMenuContainer>
+              <S.AdminMenuTitle>MENU</S.AdminMenuTitle>
+              {menuList.map((menu: any, index: number) => (
+                <S.AdminMenuContent
+                  key={index}
+                  onClick={() => {
+                    handleMoveToMenu(menu.path);
+                  }}
+                >
+                  {menu.label}
+                </S.AdminMenuContent>
+              ))}
+            </S.AdminMenuContainer>
+          </S.Overlay>
+        )}
       </S.MenuContainer>
     </S.HeaderContainer>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,8 +2,8 @@ import * as S from "../styles/Header.styles";
 import Logo from "../assets/img_logo.png";
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router";
-import AdminMenu from "./Menu/AdminMenu";
-import Menu from "./Menu/Menu";
+import AdminMenu from "./menu/AdminMenu";
+import Menu from "./menu/Menu";
 
 export default function Header() {
   const [login, setLogin] = useState({ user: "user" });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,24 +1,13 @@
 import * as S from "../styles/Header.styles";
 import Logo from "../assets/img_logo.png";
-import { getMenuList } from "../hooks/getMenuList";
 import { useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router";
+import { useLocation } from "react-router";
+import AdminMenu from "./Menu/AdminMenu";
+import Menu from "./Menu/Menu";
 
 export default function Header() {
   const [login, setLogin] = useState({ user: "user" });
-  const [onMenu, setonMenu] = useState<boolean>(false);
-
-  const menuList = getMenuList(login);
-  const navigate = useNavigate();
   const locationObject = useLocation();
-
-  const handleMoveToMenu = (path: string) => {
-    navigate(path);
-  };
-
-  const handleMenu = () => {
-    setonMenu(!onMenu);
-  };
 
   // 로그인 구현 전에 임시로 만든 코드입니다.
   useEffect(() => {
@@ -26,7 +15,6 @@ export default function Header() {
       setLogin({ user: "admin" });
     }
   }, []);
-
   return (
     <S.HeaderContainer>
       <S.LogoContainer>
@@ -34,45 +22,9 @@ export default function Header() {
       </S.LogoContainer>
       <S.MenuContainer>
         {login.user !== "admin" ? (
-          menuList.map((menu: any, index: number) => (
-            <S.Menu
-              key={index}
-              onClick={() => {
-                handleMoveToMenu(menu.path);
-              }}
-            >
-              {menu.label}
-            </S.Menu>
-          ))
+          <Menu login={login}/>
         ) : (
-          <S.Menu
-            onClick={() => {
-              handleMenu();
-            }}
-          >
-            MENU
-          </S.Menu>
-        )}
-        {onMenu && (
-          <S.Overlay
-            onClick={() => {
-              handleMenu();
-            }}
-          >
-            <S.AdminMenuContainer>
-              <S.AdminMenuTitle>MENU</S.AdminMenuTitle>
-              {menuList.map((menu: any, index: number) => (
-                <S.AdminMenuContent
-                  key={index}
-                  onClick={() => {
-                    handleMoveToMenu(menu.path);
-                  }}
-                >
-                  {menu.label}
-                </S.AdminMenuContent>
-              ))}
-            </S.AdminMenuContainer>
-          </S.Overlay>
+          <AdminMenu login={login}/>
         )}
       </S.MenuContainer>
     </S.HeaderContainer>

--- a/src/components/Menu/AdminMenu.tsx
+++ b/src/components/Menu/AdminMenu.tsx
@@ -1,0 +1,106 @@
+import styled from "styled-components";
+import { breakPoints } from "../../styles/breakPoints";
+import { useState } from "react";
+import { getMenuList } from "../../hooks/getMenuList";
+import { useNavigate } from "react-router";
+
+interface Ilogin {
+  login: {user:string};
+}
+
+export default function AdminMenu({login}:Ilogin) {
+    const [onMenu, setonMenu] = useState<boolean>(false);
+    const menuList = getMenuList(login);
+    const navigate = useNavigate();
+    
+    const handleMoveToMenu = (path: string) => {
+        navigate(path);
+      };
+    const handleMenu = () => {
+        setonMenu(!onMenu);
+      };
+    return <>
+        <Menu
+            onClick={() => {
+              handleMenu();
+            }}
+          >
+            MENU
+          </Menu>
+          {onMenu && (
+          <Overlay
+            onClick={() => {
+              handleMenu();
+            }}
+          >
+            <AdminMenuContainer>
+              <AdminMenuTitle>MENU</AdminMenuTitle>
+              {menuList.map((menu: any, index: number) => (
+                <AdminMenuContent
+                  key={index}
+                  onClick={() => {
+                    handleMoveToMenu(menu.path);
+                  }}
+                >
+                  {menu.label}
+                </AdminMenuContent>
+              ))}
+            </AdminMenuContainer>
+          </Overlay>
+        )}
+    </>
+}
+
+export const Menu = styled.button`
+  font-size: var(--font-size-400);
+  font-weight: 700;
+
+  @media screen and (max-width: ${breakPoints.small}px) {
+    font-size: var(--font-size-600);
+  }
+`;
+
+export const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`
+
+export const AdminMenuContainer = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 300px;
+  height: 500px;
+  border-bottom-left-radius: 20px;
+  background-color: var(--main-color-300);
+  box-shadow: 4px 3px 4px rgba(0,0,0,0.30);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 35px;
+  
+  @media screen and (max-width: ${breakPoints.small}px) {
+    width: 250px;
+  }
+`
+
+export const AdminMenuTitle = styled.div`
+  font-size: var(--font-size-300);
+  font-weight: 700;
+  margin-top: 30px;
+  margin-bottom: 20px;
+  @media screen and (max-width: ${breakPoints.small}px) {
+    font-size: var(--font-size-500);
+  }
+`
+
+export const AdminMenuContent = styled.div`
+  font-size: var(--font-size-400);
+
+  @media screen and (max-width: ${breakPoints.small}px) {
+    font-size: var(--font-size-600);
+  }
+`

--- a/src/components/Menu/AdminMenu.tsx
+++ b/src/components/Menu/AdminMenu.tsx
@@ -1,106 +1,55 @@
-import styled from "styled-components";
-import { breakPoints } from "../../styles/breakPoints";
 import { useState } from "react";
 import { getMenuList } from "../../hooks/getMenuList";
 import { useNavigate } from "react-router";
+import * as S from "../../styles/menu/Menu.styles";
+
 
 interface Ilogin {
-  login: {user:string};
+  login: { user: string };
 }
 
-export default function AdminMenu({login}:Ilogin) {
-    const [onMenu, setonMenu] = useState<boolean>(false);
-    const menuList = getMenuList(login);
-    const navigate = useNavigate();
-    
-    const handleMoveToMenu = (path: string) => {
-        navigate(path);
-      };
-    const handleMenu = () => {
-        setonMenu(!onMenu);
-      };
-    return <>
-        <Menu
-            onClick={() => {
-              handleMenu();
-            }}
-          >
-            MENU
-          </Menu>
-          {onMenu && (
-          <Overlay
-            onClick={() => {
-              handleMenu();
-            }}
-          >
-            <AdminMenuContainer>
-              <AdminMenuTitle>MENU</AdminMenuTitle>
-              {menuList.map((menu: any, index: number) => (
-                <AdminMenuContent
-                  key={index}
-                  onClick={() => {
-                    handleMoveToMenu(menu.path);
-                  }}
-                >
-                  {menu.label}
-                </AdminMenuContent>
-              ))}
-            </AdminMenuContainer>
-          </Overlay>
-        )}
+export default function AdminMenu({ login }: Ilogin) {
+  const [onMenu, setonMenu] = useState<boolean>(false);
+  const menuList = getMenuList(login);
+  const navigate = useNavigate();
+
+  const handleMoveToMenu = (path: string) => {
+    navigate(path);
+  };
+  const handleMenu = () => {
+    setonMenu(!onMenu);
+  };
+  return (
+    <>
+      <S.Content
+        onClick={() => {
+          handleMenu();
+        }}
+      >
+        MENU
+      </S.Content>
+      {onMenu && (
+        <S.Overlay
+          onClick={() => {
+            handleMenu();
+          }}
+        >
+          <S.AdminMenuContainer>
+            <S.AdminMenuTitle>MENU</S.AdminMenuTitle>
+            {menuList.map((menu: any, index: number) => (
+              <S.AdminMenuContent
+                key={index}
+                onClick={() => {
+                  handleMoveToMenu(menu.path);
+                }}
+              >
+                {menu.label}
+              </S.AdminMenuContent>
+            ))}
+          </S.AdminMenuContainer>
+        </S.Overlay>
+      )}
     </>
+  );
 }
 
-export const Menu = styled.button`
-  font-size: var(--font-size-400);
-  font-weight: 700;
-
-  @media screen and (max-width: ${breakPoints.small}px) {
-    font-size: var(--font-size-600);
-  }
-`;
-
-export const Overlay = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-`
-
-export const AdminMenuContainer = styled.div`
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 300px;
-  height: 500px;
-  border-bottom-left-radius: 20px;
-  background-color: var(--main-color-300);
-  box-shadow: 4px 3px 4px rgba(0,0,0,0.30);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 35px;
-  
-  @media screen and (max-width: ${breakPoints.small}px) {
-    width: 250px;
-  }
-`
-
-export const AdminMenuTitle = styled.div`
-  font-size: var(--font-size-300);
-  font-weight: 700;
-  margin-top: 30px;
-  margin-bottom: 20px;
-  @media screen and (max-width: ${breakPoints.small}px) {
-    font-size: var(--font-size-500);
-  }
-`
-
-export const AdminMenuContent = styled.div`
-  font-size: var(--font-size-400);
-
-  @media screen and (max-width: ${breakPoints.small}px) {
-    font-size: var(--font-size-600);
-  }
-`

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,9 +1,7 @@
-import styled from "styled-components";
 import { getMenuList } from "../../hooks/getMenuList";
-import { breakPoints } from "../../styles/breakPoints";
 import { useNavigate } from "react-router";
 import { useState } from "react";
-import { CommonButton } from "../../styles/globalStyles";
+import * as S from "../../styles/menu/Menu.styles";
 
 interface Ilogin {
   login: { user: string };
@@ -23,106 +21,36 @@ export default function Menu({ login }: Ilogin) {
   return (
     <>
       {menuList.map((menu: any, index: number) => (
-        <Content
+        <S.Content
           key={index}
           onClick={() => {
             handleMoveToMenu(menu.path);
           }}
         >
           {menu.label}
-        </Content>
+        </S.Content>
       ))}
-      <Profile
+      <S.Profile
         onClick={() => {
           handleMenu();
         }}
       />
       {onMenu && (
-        <Overlay
+        <S.Overlay
           onClick={() => {
             handleMenu();
           }}
         >
-          <ProfileMenu>
-            <Infomation>abc@abc.com</Infomation>
-            <Infomation>홍길동</Infomation>
-            <ProfileButtons>
-              <Button>수정하기</Button>
-              <Button>로그아웃</Button>
-            </ProfileButtons>
-          </ProfileMenu>
-        </Overlay>
+          <S.ProfileMenu>
+            <S.Infomation>abc@abc.com</S.Infomation>
+            <S.Infomation>홍길동</S.Infomation>
+            <S.ProfileButtons>
+              <S.Button>수정하기</S.Button>
+              <S.Button>로그아웃</S.Button>
+            </S.ProfileButtons>
+          </S.ProfileMenu>
+        </S.Overlay>
       )}
     </>
   );
 }
-
-export const Content = styled.button`
-  font-size: var(--font-size-400);
-  font-weight: 700;
-
-  @media screen and (max-width: ${breakPoints.small}px) {
-    font-size: var(--font-size-600);
-  }
-`;
-
-export const Profile = styled.button`
-  margin-left: 10px;
-  width: 40px;
-  height: 40px;
-  background-color: var(--white-color-500);
-  border-radius: 100%;
-  &:hover {
-    box-shadow: 0 0 11px rgba(102, 102, 102, 0.25);
-  }
-`;
-
-export const Overlay = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-`;
-
-export const ProfileMenu = styled.div`
-  position: absolute;
-  top: 90px;
-  right: 0;
-  width: 320px;
-  height: 150px;
-  background-color: var(--main-color-300);
-  border-radius: 0 0 15px 15px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap:20px;
-  padding-top: 2%;
-`;
-
-export const Infomation = styled.div`
-  font-size: var(--font-size-400);
-  font-weight: 700;
-
-  @media screen and (max-width: ${breakPoints.small}px) {
-    font-size: var(--font-size-600);
-  }
-`
-
-
-export const ProfileButtons = styled.div`
-  display: flex;
-  gap: 20px;
-`
-export const Button = styled(CommonButton)`
-  background-color: var(--main-color-400);
-  width: 80px;
-  height: 30px;
-  font-size: var(--font-size-500);
-  &:hover {
-    background-color: var(--main-color-500);
-  }
-`
-
-
-

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -2,17 +2,23 @@ import styled from "styled-components";
 import { getMenuList } from "../../hooks/getMenuList";
 import { breakPoints } from "../../styles/breakPoints";
 import { useNavigate } from "react-router";
+import { useState } from "react";
+import { CommonButton } from "../../styles/globalStyles";
 
 interface Ilogin {
-  login: {user:string};
+  login: { user: string };
 }
 
-
-export default function Menu({login}:Ilogin) {
+export default function Menu({ login }: Ilogin) {
+  const [onMenu, setonMenu] = useState<boolean>(false);
   const menuList = getMenuList(login);
   const navigate = useNavigate();
+
   const handleMoveToMenu = (path: string) => {
     navigate(path);
+  };
+  const handleMenu = () => {
+    setonMenu(!onMenu);
   };
   return (
     <>
@@ -26,6 +32,27 @@ export default function Menu({login}:Ilogin) {
           {menu.label}
         </Content>
       ))}
+      <Profile
+        onClick={() => {
+          handleMenu();
+        }}
+      />
+      {onMenu && (
+        <Overlay
+          onClick={() => {
+            handleMenu();
+          }}
+        >
+          <ProfileMenu>
+            <Infomation>abc@abc.com</Infomation>
+            <Infomation>홍길동</Infomation>
+            <ProfileButtons>
+              <Button>수정하기</Button>
+              <Button>로그아웃</Button>
+            </ProfileButtons>
+          </ProfileMenu>
+        </Overlay>
+      )}
     </>
   );
 }
@@ -38,3 +65,64 @@ export const Content = styled.button`
     font-size: var(--font-size-600);
   }
 `;
+
+export const Profile = styled.button`
+  margin-left: 10px;
+  width: 40px;
+  height: 40px;
+  background-color: var(--white-color-500);
+  border-radius: 100%;
+  &:hover {
+    box-shadow: 0 0 11px rgba(102, 102, 102, 0.25);
+  }
+`;
+
+export const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`;
+
+export const ProfileMenu = styled.div`
+  position: absolute;
+  top: 90px;
+  right: 0;
+  width: 320px;
+  height: 150px;
+  background-color: var(--main-color-300);
+  border-radius: 0 0 15px 15px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap:20px;
+  padding-top: 2%;
+`;
+
+export const Infomation = styled.div`
+  font-size: var(--font-size-400);
+  font-weight: 700;
+
+  @media screen and (max-width: ${breakPoints.small}px) {
+    font-size: var(--font-size-600);
+  }
+`
+
+
+export const ProfileButtons = styled.div`
+  display: flex;
+  gap: 20px;
+`
+export const Button = styled(CommonButton)`
+  background-color: var(--main-color-400);
+  width: 80px;
+  height: 30px;
+  font-size: var(--font-size-500);
+  &:hover {
+    background-color: var(--main-color-500);
+  }
+`
+
+
+

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,0 +1,40 @@
+import styled from "styled-components";
+import { getMenuList } from "../../hooks/getMenuList";
+import { breakPoints } from "../../styles/breakPoints";
+import { useNavigate } from "react-router";
+
+interface Ilogin {
+  login: {user:string};
+}
+
+
+export default function Menu({login}:Ilogin) {
+  const menuList = getMenuList(login);
+  const navigate = useNavigate();
+  const handleMoveToMenu = (path: string) => {
+    navigate(path);
+  };
+  return (
+    <>
+      {menuList.map((menu: any, index: number) => (
+        <Content
+          key={index}
+          onClick={() => {
+            handleMoveToMenu(menu.path);
+          }}
+        >
+          {menu.label}
+        </Content>
+      ))}
+    </>
+  );
+}
+
+export const Content = styled.button`
+  font-size: var(--font-size-400);
+  font-weight: 700;
+
+  @media screen and (max-width: ${breakPoints.small}px) {
+    font-size: var(--font-size-600);
+  }
+`;

--- a/src/hooks/getMenuList.ts
+++ b/src/hooks/getMenuList.ts
@@ -42,6 +42,18 @@ export class MenuFactory {
           label: "배너 관리",
           path: "/admin/banner",
         },
+        {
+          label: "상품 관리",
+          path: "/admin/product",
+        },
+        {
+          label: "이용권 관리",
+          path: "/admin/program",
+        },
+        {
+          label: "승인 요청 관리",
+          path: "/admin/admit-request",
+        },
       ];
     }
 

--- a/src/hooks/getMenuList.ts
+++ b/src/hooks/getMenuList.ts
@@ -1,13 +1,15 @@
 // TODO login, menuList type 지정 필요
 
 export class MenuFactory {
-  baseMenu = [{ label: "PlanIt?", path: "/about" }];
-
   public createMenuList(login: any) {
     let menu: any = [];
 
     if (login.user === "user") {
       menu = [
+        { 
+          label: "PlanIt?", 
+          path: "/about" 
+        },
         {
           label: "이용권",
           path: "/user/ticket",
@@ -21,6 +23,10 @@ export class MenuFactory {
 
     if (login.user === "trainer") {
       menu = [
+        { 
+          label: "PlanIt?", 
+          path: "/about" 
+        },
         {
           label: "스케줄",
           path: "/trainer/schedule",
@@ -57,7 +63,7 @@ export class MenuFactory {
       ];
     }
 
-    return [...this.baseMenu, ...menu];
+    return [...menu];
   }
 }
 

--- a/src/hooks/getMenuList.ts
+++ b/src/hooks/getMenuList.ts
@@ -1,8 +1,9 @@
 // TODO login, menuList type 지정 필요
 
+
 export class MenuFactory {
   public createMenuList(login: any) {
-    let menu: any = [];
+    let menu:any = [];
 
     if (login.user === "user") {
       menu = [

--- a/src/pages/admin/AdmitRequest.tsx
+++ b/src/pages/admin/AdmitRequest.tsx
@@ -1,0 +1,4 @@
+export default function AdmitRequest() {
+    return <div>승인 요청 관리</div>;
+  }
+  

--- a/src/pages/admin/Product.tsx
+++ b/src/pages/admin/Product.tsx
@@ -1,0 +1,4 @@
+export default function Product() {
+    return <div>상품관리</div>;
+  }
+  

--- a/src/pages/admin/Program.tsx
+++ b/src/pages/admin/Program.tsx
@@ -1,0 +1,4 @@
+export default function Program() {
+    return <div>이용권 관리</div>;
+  }
+  

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -18,6 +18,9 @@ import UserRoute from "./UserRoute";
 import TrainerRoute from "./TrainerRoute";
 import AdminRoute from "./AdminRoute";
 import Layout from "../components/Layout";
+import Product from "../pages/admin/Product";
+import Program from "../pages/admin/Program";
+import AdmitRequest from "../pages/admin/AdmitRequest";
 
 export const router = createBrowserRouter([
   {
@@ -61,6 +64,9 @@ export const router = createBrowserRouter([
               { path: "/admin/account", element: <Account /> },
               { path: "/admin/trainer", element: <Trainer /> },
               { path: "/admin/banner", element: <Banner /> },
+              { path: "/admin/product", element: <Product /> },
+              { path: "/admin/program", element: <Program /> },
+              { path: "/admin/admit-request", element: <AdmitRequest /> },
             ],
           },
         ],

--- a/src/styles/Header.styles.ts
+++ b/src/styles/Header.styles.ts
@@ -62,11 +62,12 @@ export const AdminMenuContainer = styled.div`
   height: 500px;
   border-bottom-left-radius: 20px;
   background-color: var(--main-color-300);
+  box-shadow: 4px 4px 4px rgba(0,0,0,0.25);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 30px;
-
+  gap: 35px;
+  
   @media screen and (max-width: ${breakPoints.small}px) {
     width: 250px;
   }

--- a/src/styles/Header.styles.ts
+++ b/src/styles/Header.styles.ts
@@ -31,6 +31,7 @@ export const LogoContainer = styled.div`
 `;
 
 export const MenuContainer = styled.div`
+  position: relative;
   display: flex;
   align-items: center;
   gap: 20px;
@@ -44,3 +45,47 @@ export const Menu = styled.button`
     font-size: var(--font-size-600);
   }
 `;
+
+export const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`
+
+export const AdminMenuContainer = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 300px;
+  height: 500px;
+  border-bottom-left-radius: 20px;
+  background-color: var(--main-color-300);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 30px;
+
+  @media screen and (max-width: ${breakPoints.small}px) {
+    width: 250px;
+  }
+`
+
+export const AdminMenuTitle = styled.div`
+  font-size: var(--font-size-300);
+  font-weight: 700;
+  margin-top: 30px;
+  margin-bottom: 20px;
+  @media screen and (max-width: ${breakPoints.small}px) {
+    font-size: var(--font-size-500);
+  }
+`
+
+export const AdminMenuContent = styled.div`
+  font-size: var(--font-size-400);
+
+  @media screen and (max-width: ${breakPoints.small}px) {
+    font-size: var(--font-size-600);
+  }
+`

--- a/src/styles/Header.styles.ts
+++ b/src/styles/Header.styles.ts
@@ -62,7 +62,7 @@ export const AdminMenuContainer = styled.div`
   height: 500px;
   border-bottom-left-radius: 20px;
   background-color: var(--main-color-300);
-  box-shadow: 4px 4px 4px rgba(0,0,0,0.25);
+  box-shadow: 4px 3px 4px rgba(0,0,0,0.30);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/styles/Header.styles.ts
+++ b/src/styles/Header.styles.ts
@@ -9,6 +9,7 @@ export const HeaderContainer = styled.header`
   width: calc(100% - 20px);
   height: 80px;
   background-color: #f6ffff;
+  z-index: 2;
 `;
 
 export const LogoContainer = styled.div`

--- a/src/styles/menu/Menu.styles.ts
+++ b/src/styles/menu/Menu.styles.ts
@@ -1,0 +1,107 @@
+import styled from "styled-components";
+import { breakPoints } from "../breakPoints";
+import { CommonButton } from "../globalStyles";
+
+export const Content = styled.button`
+  font-size: var(--font-size-400);
+  font-weight: 700;
+
+  @media screen and (max-width: ${breakPoints.small}px) {
+    font-size: var(--font-size-600);
+  }
+`;
+
+export const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`;
+
+export const AdminMenuContainer = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 300px;
+  height: 500px;
+  border-bottom-left-radius: 20px;
+  background-color: var(--main-color-300);
+  box-shadow: 4px 3px 4px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 35px;
+
+  @media screen and (max-width: ${breakPoints.small}px) {
+    width: 250px;
+  }
+`;
+
+export const AdminMenuTitle = styled.div`
+  font-size: var(--font-size-300);
+  font-weight: 700;
+  margin-top: 30px;
+  margin-bottom: 20px;
+  @media screen and (max-width: ${breakPoints.small}px) {
+    font-size: var(--font-size-500);
+  }
+`;
+
+export const AdminMenuContent = styled.div`
+  font-size: var(--font-size-400);
+
+  @media screen and (max-width: ${breakPoints.small}px) {
+    font-size: var(--font-size-600);
+  }
+`;
+
+export const Profile = styled.button`
+  margin-left: 10px;
+  width: 40px;
+  height: 40px;
+  background-color: var(--white-color-500);
+  border-radius: 100%;
+  &:hover {
+    box-shadow: 0 0 11px rgba(102, 102, 102, 0.25);
+  }
+`;
+
+export const ProfileMenu = styled.div`
+  position: absolute;
+  top: 90px;
+  right: 0;
+  width: 320px;
+  height: 150px;
+  background-color: var(--main-color-300);
+  border-radius: 0 0 15px 15px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap:20px;
+  padding-top: 2%;
+`;
+
+export const Infomation = styled.div`
+  font-size: var(--font-size-400);
+  font-weight: 700;
+
+  @media screen and (max-width: ${breakPoints.small}px) {
+    font-size: var(--font-size-600);
+  }
+`
+
+
+export const ProfileButtons = styled.div`
+  display: flex;
+  gap: 20px;
+`
+export const Button = styled(CommonButton)`
+  background-color: var(--main-color-400);
+  width: 80px;
+  height: 30px;
+  font-size: var(--font-size-500);
+  &:hover {
+    background-color: var(--main-color-500);
+  }
+`


### PR DESCRIPTION
## Why need this change? 🧐
- 어드민 계정 접속 시에 표시되는 메뉴와 유저, 트레이너 계정 접속시에 표시되는 메뉴가 달라서 컴포넌트를 분리해서 작업했습니다. 

<br />

## Changes made ✍🏻
-  getMenuList.ts 수정
- AdminMenu.tsx, Menu.tsx 추가
- Header.tsx에 위의 두 컴포넌트 import
- styles/menu/Menu.styles.ts 추가

<br />

## Screenshot (optional) 📸
![image](https://github.com/PlanIt-Project/front-end/assets/93645009/eb9bc4f4-d13a-4c56-aa73-9b6f482adada)
<br/>
![image](https://github.com/PlanIt-Project/front-end/assets/93645009/17b5d6ec-7130-4781-a62a-aae258b3b183)


<br />

## 추신
혜린님이 만들어두신 Header.tsx 와 getMenuList.ts를 수정해서 작업했습니다.
아무래도 user,trainer랑 admin이 메뉴가 표시되는 형식이 달라서 좀 많이 수정을 했습니다.
코드 로직에서 바꿀 점이 있다면 알려주시면 감사드리겠습니다